### PR TITLE
[WIP] redo copy-images with cross-vCenter cloning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go: 1.8
+install:
+- make prereqs
+- make deps
+script:
+- make build
+- make test

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,6 @@ prereqs:
 copyright:
 	sed -i "s/^Copyright.*Travis CI/Copyright © $(shell date +%Y) Travis CI/" LICENSE
 
-vendor/.deps-fetched:
+vendor/.deps-fetched: vendor/manifest
 	gvt rebuild
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GENERATED_VALUE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%S%z')
 COPYRIGHT_VAR := main.CopyrightString
 COPYRIGHT_VALUE ?= $(shell grep -i ^copyright LICENSE | sed 's/^[Cc]opyright //')
 
-GOPATH := $(shell echo $${GOPATH%%:*})
+GOPATH := $(shell go env GOPATH)
 GOBUILD_LDFLAGS ?= \
     -X '$(VERSION_VAR)=$(VERSION_VALUE)' \
     -X '$(REV_VAR)=$(REV_VALUE)' \

--- a/Makefile
+++ b/Makefile
@@ -34,19 +34,19 @@ clean:
 .PHONY: test
 test:
 	for package in $(TEST_PACKAGES); do \
-		go test -x -v \
+		go test $(GOBUILDFLAGS) -v \
 			$${package}; \
 	done
 
 .PHONY: build
 build: deps
-	go install -x -ldflags "$(GOBUILD_LDFLAGS)" $(MAIN_PACKAGE)
+	go install $(GOBUILDFLAGS) -ldflags "$(GOBUILD_LDFLAGS)" $(MAIN_PACKAGE)
 
 .PHONY: crossbuild
 crossbuild: deps
-	GOARCH=amd64 GOOS=darwin go build -o build/darwin/amd64/vsphere-images \
+	GOARCH=amd64 GOOS=darwin go build $(GOBUILDFLAGS) -o build/darwin/amd64/vsphere-images \
 		-ldflags "$(GOBUILD_LDFLAGS)" $(MAIN_PACKAGE)
-	GOARCH=amd64 GOOS=linux go build -o build/linux/amd64/vsphere-images \
+	GOARCH=amd64 GOOS=linux go build $(GOBUILDFLAGS) -o build/linux/amd64/vsphere-images \
 		-ldflags "$(GOBUILD_LDFLAGS)" $(MAIN_PACKAGE)
 
 .PHONY: distclean

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ROOT_PACKAGE := github.com/travis-ci/vsphere-images
 MAIN_PACKAGE := $(ROOT_PACKAGE)/cmd/vsphere-images
-TEST_PACKAGE := $(ROOT_PACKAGE)
+TEST_PACKAGES := $(ROOT_PACKAGE) $(MAIN_PACKAGE)
 COVER_PACKAGES := $(ROOT_PACKAGE),$(MAIN_PACKAGE)
 
 VERSION_VAR := main.VersionString

--- a/README.md
+++ b/README.md
@@ -8,18 +8,14 @@ Copy `foobar` from vSphere 192.0.2.1 to 192.0.2.2:
 
 ```
 $ vphere-images copy-image \
-	-src=https://admin:password@192.0.2.1/sdk \
-	-dest=https://admin:password@192.0.2.2/sdk \
-	-dest-resource-pool=main_pool \
-	-dest-network=dvPortGroup-Foo \
-	-dest-datastore=DS-1 \
-	-dest-folder="/Datacenter-1/vm/base" \
-	-src-temp-folder="/Datacenter-1/vm/tmp" \
-	-dest-vcenter-shortname="2_2" \
-	"/Datacenter-1/vm/base/foobar"
+	-src-url=https://admin:password@192.0.2.1/sdk \
+	-dest-url=https://admin:password@192.0.2.2/sdk \
+	-dest-datastore-path=/Datacenter-2/datastore/DS-1 \
+	-dest-pool-path=/Datacenter-2/host/main_pool \
+	-dest-host-path=/Datacenter-2/host/main_pool/host01 \
+	"/Datacenter-1/vm/base/foobar" \
+	"/Datacenter-2/vm/base/foobar"
 ```
-
-This takes the image named `foobar` in the folder `base` in 192.0.2.1 and makes a clone of it, places it in the `dest-datastore` datastore in a folder named `2_2_templates` and registers it in 192.0.2.2 as `base/foobar`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ $ vphere-images copy-image \
 	--dest-datastore-path=/Datacenter-2/datastore/DS-1 \
 	--dest-pool-path=/Datacenter-2/host/main_pool \
 	--dest-host-path=/Datacenter-2/host/main_pool/host01 \
+	--dest-network-name=/Datacenter-2/network/PortGroupName \
 	"/Datacenter-1/vm/base/foobar" \
 	"/Datacenter-2/vm/base/foobar"
 ```

--- a/README.md
+++ b/README.md
@@ -8,12 +8,32 @@ Copy `foobar` from vSphere 192.0.2.1 to 192.0.2.2:
 
 ```
 $ vphere-images copy-image \
-	-src-url=https://admin:password@192.0.2.1/sdk \
-	-dest-url=https://admin:password@192.0.2.2/sdk \
-	-dest-datastore-path=/Datacenter-2/datastore/DS-1 \
-	-dest-pool-path=/Datacenter-2/host/main_pool \
-	-dest-host-path=/Datacenter-2/host/main_pool/host01 \
+	--src-url=https://admin:password@192.0.2.1/sdk \
+	--dest-url=https://admin:password@192.0.2.2/sdk \
+	--dest-datastore-path=/Datacenter-2/datastore/DS-1 \
+	--dest-pool-path=/Datacenter-2/host/main_pool \
+	--dest-host-path=/Datacenter-2/host/main_pool/host01 \
 	"/Datacenter-1/vm/base/foobar" \
+	"/Datacenter-2/vm/base/foobar"
+```
+
+The destination pool and host are both required, even if the destination pool has DRS enabled.
+
+### Move image in datastore
+
+```
+$ vsphere-images datastore-move \
+	--vsphere-url=https://admin:password@192.0.2.1/sdk \
+	"/Datacenter-2/vm/base/foobar" \
+	"[DS-1] /foobar" \
+	"[DS-1] /images/foobar"
+```
+
+### Resnapshot an image
+
+```
+$ vsphere-images resnapshot \
+	--vsphere-url=https://admin:password@192.0.2.1/sdk \
 	"/Datacenter-2/vm/base/foobar"
 ```
 

--- a/cmd/vsphere-images/copy-image.go
+++ b/cmd/vsphere-images/copy-image.go
@@ -83,8 +83,7 @@ func copyImageAction(c *cli.Context) error {
 		return errors.Wrap(err, "parsing destination URL failed")
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := context.Background()
 
 	source := vsphereimages.ImageSource{
 		VSphereEndpoint:           srcURL,

--- a/cmd/vsphere-images/copy-image.go
+++ b/cmd/vsphere-images/copy-image.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var copyImageCommand = cli.Command{
+	Name:      "copy-image",
+	Usage:     "copy image from one vCenter to another",
+	ArgsUsage: "image-name",
+	Action:    copyImageAction,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:   "src",
+			Usage:  "URL to the source vCenter",
+			EnvVar: "VSPHERE_IMAGES_SRC_URL",
+		},
+		cli.StringFlag{
+			Name:   "dest",
+			Usage:  "URL to the destination vCenter",
+			EnvVar: "VSPHERE_IMAGES_DEST_URL",
+		},
+		cli.StringFlag{
+			Name:   "dest-vcenter-shortname",
+			Usage:  "Short name for destination vCenter to use in paths",
+			EnvVar: "VSPHERE_IMAGES_DEST_VCENTER_SHORTNAME",
+		},
+		cli.StringFlag{
+			Name:   "src-temp-folder",
+			Usage:  "Inventory folder in the source vCenter to use for temporary storage",
+			EnvVar: "VSPHERE_IMAGES_SRC_TEMP_FOLDER",
+		},
+		cli.StringFlag{
+			Name:   "dest-vcenter-ssl-thumbprint",
+			Usage:  "The :-separated SHA1 SSL fingerprint for the destination vCenter",
+			EnvVar: "VSPHERE_IMAGES_DEST_VCENTER_SSL_THUMBPRINT",
+		},
+	},
+}
+
+func copyImageAction(c *cli.Context) error {
+	srcStringURL := c.String("src")
+	destStringURL := c.String("dest")
+
+	srcURL, err := url.Parse(srcStringURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "couldn't parse source URL: %v\n", err)
+		os.Exit(1)
+	}
+	destURL, err := url.Parse(destStringURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "couldn't parse destination URL: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srcClient, err := govmomi.NewClient(ctx, srcURL, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "couldn't create source vSphere client: %v\n", err)
+		os.Exit(1)
+	}
+
+	_, err = govmomi.NewClient(ctx, destURL, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "couldn't create destination vSphere client: %v\n", err)
+		os.Exit(1)
+	}
+
+	name := fmt.Sprintf("%s_%s", c.String("dest-vcenter-shortname"), path.Base(c.Args().First()))
+
+	_, err = cloneVM(ctx, srcClient, c.Args().First(), c.String("src-temp-folder"), name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error cloning VM: %v\n", err)
+		os.Exit(1)
+	}
+
+	//  unregister_vm
+	//
+	//  export GOVC_URL="${BASE_VM_DST_VCENTER}"
+	//  # move the $Base_VM into a folder for $vCenter02 inside the datastore
+	//  move_vm_in_datastore
+	//
+	//  # register the $Base_VM in $vCenter02
+	//  register_vm_in_vcenter "${BASE_VM_DST_DATASTORE}"
+	//
+	//  # update network card
+	//  update_network "${BASE_VM_DST_FOLDER}/${BASE_VM_NAME}" "${BASE_VM_NETWORK}"
+	//
+	//  # this will remove any existing snapshots and make a new `base`
+	//  base_snapshot "${BASE_VM_DST_FOLDER}/${BASE_VM_NAME}"
+
+	return nil
+}
+
+func cloneVM(ctx context.Context, srcClient *govmomi.Client, baseVMPath, srcTempFolder, name string) (*object.VirtualMachine, error) {
+	// Find the base VM
+	vm, err := findVM(ctx, srcClient, baseVMPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't find base VM")
+	}
+
+	searchIndex := object.NewSearchIndex(srcClient.Client)
+	folderRef, err := searchIndex.FindByInventoryPath(ctx, srcTempFolder)
+	if err != nil {
+		return nil, errors.Wrap(err, "error searching for src temp folder")
+	}
+	if folderRef == nil {
+		return nil, errors.Errorf("src temp folder not found: %s", srcTempFolder)
+	}
+	folder, ok := folderRef.(*object.Folder)
+	if !ok {
+		return nil, errors.Errorf("src temp folder is not a folder but a %T", folderRef)
+	}
+
+	cloneSpec := types.VirtualMachineCloneSpec{}
+
+	cloneTask, err := vm.Clone(ctx, folder, name, cloneSpec)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't clone VM")
+	}
+
+	info, err := cloneTask.WaitForResult(ctx, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error cloning VM")
+	}
+
+	return object.NewVirtualMachine(srcClient.Client, info.Result.(types.ManagedObjectReference)), nil
+}
+
+func findVM(ctx context.Context, client *govmomi.Client, path string) (*object.VirtualMachine, error) {
+	searchIndex := object.NewSearchIndex(client.Client)
+	vmRef, err := searchIndex.FindByInventoryPath(ctx, path)
+	if err != nil {
+		return nil, errors.Wrap(err, "error searching for VM")
+	}
+	if vmRef == nil {
+		return nil, errors.Wrap(err, "couldn't find VM")
+	}
+
+	vm, ok := vmRef.(*object.VirtualMachine)
+	if !ok {
+		return nil, errors.Errorf("VM is not a VM but a %T", vmRef)
+	}
+
+	return vm, nil
+}
+
+func unregisterVM(ctx context.Context, client *govmomi.Client, path string) error {
+	vm, err := findVM(ctx, client, path)
+	if err != nil {
+		return errors.Wrap(err, "couldn't find VM to unregister")
+	}
+
+	return errors.Wrap(vm.Unregister(ctx), "couldn't unregister VM")
+}

--- a/cmd/vsphere-images/copy-image.go
+++ b/cmd/vsphere-images/copy-image.go
@@ -2,18 +2,12 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"io"
 	"net/url"
-	"os"
 	"path"
-	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 	vsphereimages "github.com/travis-ci/vsphere-images"
 	"github.com/urfave/cli"
-	"github.com/vmware/govmomi/vim25/progress"
 )
 
 var copyImageCommand = cli.Command{
@@ -111,98 +105,4 @@ func copyImageAction(c *cli.Context) error {
 	logger.Wait()
 
 	return nil
-}
-
-type progressLogger struct {
-	prefix string
-	wg     sync.WaitGroup
-
-	sink chan chan progress.Report
-	done chan struct{}
-}
-
-func newProgressLogger(prefix string) *progressLogger {
-	p := &progressLogger{
-		prefix: prefix,
-
-		sink: make(chan chan progress.Report),
-		done: make(chan struct{}),
-	}
-
-	p.wg.Add(1)
-
-	go p.loopA()
-
-	return p
-}
-
-func (p *progressLogger) loopA() {
-	var err error
-
-	defer p.wg.Done()
-
-	tick := time.NewTicker(100 * time.Millisecond)
-	defer tick.Stop()
-
-	for stop := false; !stop; {
-		select {
-		case ch := <-p.sink:
-			err = p.loopB(tick, ch)
-			if err != nil {
-				stop = true
-			}
-		case <-p.done:
-			stop = true
-		case <-tick.C:
-			fmt.Fprintf(os.Stderr, "\r%s      ", p.prefix)
-		}
-	}
-
-	if err != nil && err != io.EOF {
-		fmt.Fprintf(os.Stderr, "\r%s      ", p.prefix)
-		fmt.Fprintf(os.Stderr, "\r%sError: %s\n", p.prefix, err)
-	} else {
-		fmt.Fprintf(os.Stderr, "\r%s      ", p.prefix)
-		fmt.Fprintf(os.Stderr, "\r%sOK\n", p.prefix)
-	}
-}
-
-func (p *progressLogger) loopB(tick *time.Ticker, ch <-chan progress.Report) error {
-	var r progress.Report
-	var ok bool
-	var err error
-
-	for ok = true; ok; {
-		select {
-		case r, ok = <-ch:
-			if !ok {
-				break
-			}
-			err = r.Error()
-		case <-tick.C:
-			line := "\r" + p.prefix
-			if r != nil {
-				line += fmt.Sprintf("(%.0f%%", r.Percentage())
-				detail := r.Detail()
-				if detail != "" {
-					line += fmt.Sprintf(", %s", detail)
-				}
-				line += ")"
-			}
-			fmt.Fprintf(os.Stderr, "%s", line)
-		}
-	}
-
-	return err
-}
-
-func (p *progressLogger) Sink() chan<- progress.Report {
-	ch := make(chan progress.Report)
-	p.sink <- ch
-	return ch
-}
-
-func (p *progressLogger) Wait() {
-	close(p.done)
-	p.wg.Wait()
 }

--- a/cmd/vsphere-images/copy-image.go
+++ b/cmd/vsphere-images/copy-image.go
@@ -62,6 +62,11 @@ var copyImageCommand = cli.Command{
 			Usage:  "The inventory path to the host to put the VM in in the destination vCenter",
 			EnvVar: "VSPHERE_IMAGES_DEST_HOST_PATH",
 		},
+		cli.StringFlag{
+			Name:   "dest-network-name",
+			Usage:  "The name of the network to connect the copied VM to.",
+			EnvVar: "VSPHERE_IMAGES_DEST_NETWORK_NAME",
+		},
 	},
 }
 
@@ -96,6 +101,7 @@ func copyImageAction(c *cli.Context) error {
 		ResourcePoolPath:          c.String("dest-pool-path"),
 		HostPath:                  c.String("dest-host-path"),
 		VMName:                    path.Base(c.Args().Get(1)),
+		NetworkPath:               c.String("dest-network-name"),
 	}
 
 	logger := newProgressLogger()

--- a/cmd/vsphere-images/copy-image.go
+++ b/cmd/vsphere-images/copy-image.go
@@ -2,12 +2,18 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/url"
+	"os"
 	"path"
+	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	vsphereimages "github.com/travis-ci/vsphere-images"
 	"github.com/urfave/cli"
+	"github.com/vmware/govmomi/vim25/progress"
 )
 
 var copyImageCommand = cli.Command{
@@ -92,6 +98,99 @@ func copyImageAction(c *cli.Context) error {
 		VMName:                    path.Base(c.Args().Get(1)),
 	}
 
-	err = vsphereimages.CopyImage(ctx, source, destination)
-	return errors.Wrap(err, "copying image failed")
+	logger := newProgressLogger()
+	err = vsphereimages.CopyImage(ctx, source, destination, logger)
+	if err != nil {
+		return errors.Wrap(err, "copying image failed")
+	}
+
+	logger.Wait()
+	return nil
+}
+
+type progressLogger struct {
+	wg sync.WaitGroup
+
+	sink chan chan progress.Report
+	done chan struct{}
+}
+
+func newProgressLogger() *progressLogger {
+	p := &progressLogger{
+		sink: make(chan chan progress.Report),
+		done: make(chan struct{}),
+	}
+
+	p.wg.Add(1)
+
+	go p.loopA()
+
+	return p
+}
+
+func (p *progressLogger) loopA() {
+	var err error
+
+	defer p.wg.Done()
+
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+
+	for stop := false; !stop; {
+		select {
+		case ch := <-p.sink:
+			err = p.loopB(tick, ch)
+			stop = true
+		case <-p.done:
+			stop = true
+		case <-tick.C:
+			fmt.Fprintf(os.Stderr, "\rcopying image… ")
+		}
+	}
+
+	if err != nil && err != io.EOF {
+		fmt.Fprintf(os.Stderr, "\rcopying image… Error: %s\n", err)
+	} else {
+		fmt.Fprintf(os.Stderr, "\rcopying image… OK\n")
+	}
+}
+
+func (p *progressLogger) loopB(tick *time.Ticker, ch <-chan progress.Report) error {
+	var r progress.Report
+	var ok bool
+	var err error
+
+	for ok = true; ok; {
+		select {
+		case r, ok = <-ch:
+			if !ok {
+				break
+			}
+			err = r.Error()
+		case <-tick.C:
+			line := "\rcopying image… "
+			if r != nil {
+				line += fmt.Sprintf("(%.0f%%", r.Percentage())
+				detail := r.Detail()
+				if detail != "" {
+					line += fmt.Sprintf(", %s", detail)
+				}
+				line += ")"
+			}
+			fmt.Fprintf(os.Stderr, "%s", line)
+		}
+	}
+
+	return err
+}
+
+func (p *progressLogger) Sink() chan<- progress.Report {
+	ch := make(chan progress.Report)
+	p.sink <- ch
+	return ch
+}
+
+func (p *progressLogger) Wait() {
+	close(p.done)
+	p.wg.Wait()
 }

--- a/cmd/vsphere-images/datastore-move.go
+++ b/cmd/vsphere-images/datastore-move.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/pkg/errors"
+	vsphereimages "github.com/travis-ci/vsphere-images"
+	"github.com/urfave/cli"
+)
+
+var datastoreMoveCommand = cli.Command{
+	Name:      "datastore-move",
+	Usage:     "Move the image on the underlying datastore",
+	ArgsUsage: "image-inventory-path src-datastore-path dest-datastore-path",
+	Action:    datastoreMoveAction,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:   "vsphere-url",
+			Usage:  "URL to the vSphere SDK API",
+			EnvVar: "VSPHERE_IMAGES_VSPHERE_URL",
+		},
+		cli.BoolFlag{
+			Name:   "vsphere-insecure-skip-verify",
+			Usage:  "Whether the vCenter's certificate chain and hostname should be verified",
+			EnvVar: "VSPHERE_IMAGES_VSPHERE_INSECURE_SKIP_VERIFY",
+		},
+	},
+}
+
+func datastoreMoveAction(c *cli.Context) error {
+	vSphereStringURL := c.String("vsphere-url")
+	if vSphereStringURL == "" {
+		return errors.New("the 'vsphere-url' flag is required")
+	}
+
+	vSphereURL, err := url.Parse(vSphereStringURL)
+	if err != nil {
+		return errors.Wrap(err, "parsing vSphere URL failed")
+	}
+
+	if c.NArg() != 3 {
+		return errors.New("required arguments: image-inventory-path src-datastore-path dest-datastore-path")
+	}
+
+	imagePath := c.Args().Get(0)
+	srcDatastorePath := c.Args().Get(1)
+	destDatastorePath := c.Args().Get(2)
+	ctx := context.Background()
+	logger := newProgressLogger("Moving image… ")
+
+	err = vsphereimages.DatastoreMoveImage(ctx, vSphereURL, c.Bool("vsphere-insecure-skip-verify"), imagePath, srcDatastorePath, destDatastorePath, logger)
+	if err != nil {
+		return errors.Wrap(err, "moving image failed")
+	}
+	logger.Wait()
+
+	return nil
+}

--- a/cmd/vsphere-images/main.go
+++ b/cmd/vsphere-images/main.go
@@ -1,17 +1,10 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"net/url"
 	"os"
-	"path"
 
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"github.com/vmware/govmomi"
-	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 func main() {
@@ -22,158 +15,12 @@ func main() {
 	app.Email = "contact+vsphere-images@travis-ci.org"
 
 	app.Commands = []cli.Command{
-		{
-			Name:      "copy-image",
-			Usage:     "copy image from one vCenter to another",
-			ArgsUsage: "image-name",
-			Action:    copyImageAction,
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:   "src",
-					Usage:  "URL to the source vCenter",
-					EnvVar: "VSPHERE_IMAGES_SRC_URL",
-				},
-				cli.StringFlag{
-					Name:   "dest",
-					Usage:  "URL to the destination vCenter",
-					EnvVar: "VSPHERE_IMAGES_DEST_URL",
-				},
-				cli.StringFlag{
-					Name:   "dest-vcenter-shortname",
-					Usage:  "Short name for destination vCenter to use in paths",
-					EnvVar: "VSPHERE_IMAGES_DEST_VCENTER_SHORTNAME",
-				},
-				cli.StringFlag{
-					Name:   "src-temp-folder",
-					Usage:  "Inventory folder in the source vCenter to use for temporary storage",
-					EnvVar: "VSPHERE_IMAGES_SRC_TEMP_FOLDER",
-				},
-				cli.StringFlag{
-					Name:   "dest-vcenter-ssl-thumbprint",
-					Usage:  "The :-separated SHA1 SSL fingerprint for the destination vCenter",
-					EnvVar: "VSPHERE_IMAGES_DEST_VCENTER_SSL_THUMBPRINT",
-				},
-			},
-		},
+		copyImageCommand,
 	}
 
-	app.Run(os.Args)
-}
-
-func copyImageAction(c *cli.Context) error {
-	srcStringURL := c.String("src")
-	destStringURL := c.String("dest")
-
-	srcURL, err := url.Parse(srcStringURL)
+	err := app.Run(os.Args)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "couldn't parse source URL: %v\n", err)
+		fmt.Fprintf(os.Stderr, "an error occurred: %v\n", err)
 		os.Exit(1)
 	}
-	destURL, err := url.Parse(destStringURL)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "couldn't parse destination URL: %v\n", err)
-		os.Exit(1)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	srcClient, err := govmomi.NewClient(ctx, srcURL, true)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "couldn't create source vSphere client: %v\n", err)
-		os.Exit(1)
-	}
-
-	_, err = govmomi.NewClient(ctx, destURL, true)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "couldn't create destination vSphere client: %v\n", err)
-		os.Exit(1)
-	}
-
-	name := fmt.Sprintf("%s_%s", c.String("dest-vcenter-shortname"), path.Base(c.Args().First()))
-
-	_, err = cloneVM(ctx, srcClient, c.Args().First(), c.String("src-temp-folder"), name)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error cloning VM: %v\n", err)
-		os.Exit(1)
-	}
-
-	//  unregister_vm
-	//
-	//  export GOVC_URL="${BASE_VM_DST_VCENTER}"
-	//  # move the $Base_VM into a folder for $vCenter02 inside the datastore
-	//  move_vm_in_datastore
-	//
-	//  # register the $Base_VM in $vCenter02
-	//  register_vm_in_vcenter "${BASE_VM_DST_DATASTORE}"
-	//
-	//  # update network card
-	//  update_network "${BASE_VM_DST_FOLDER}/${BASE_VM_NAME}" "${BASE_VM_NETWORK}"
-	//
-	//  # this will remove any existing snapshots and make a new `base`
-	//  base_snapshot "${BASE_VM_DST_FOLDER}/${BASE_VM_NAME}"
-
-	return nil
-}
-
-func cloneVM(ctx context.Context, srcClient *govmomi.Client, baseVMPath, srcTempFolder, name string) (*object.VirtualMachine, error) {
-	// Find the base VM
-	vm, err := findVM(ctx, srcClient, baseVMPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't find base VM")
-	}
-
-	searchIndex := object.NewSearchIndex(srcClient.Client)
-	folderRef, err := searchIndex.FindByInventoryPath(ctx, srcTempFolder)
-	if err != nil {
-		return nil, errors.Wrap(err, "error searching for src temp folder")
-	}
-	if folderRef == nil {
-		return nil, errors.Errorf("src temp folder not found: %s", srcTempFolder)
-	}
-	folder, ok := folderRef.(*object.Folder)
-	if !ok {
-		return nil, errors.Errorf("src temp folder is not a folder but a %T", folderRef)
-	}
-
-	cloneSpec := types.VirtualMachineCloneSpec{}
-
-	cloneTask, err := vm.Clone(ctx, folder, name, cloneSpec)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't clone VM")
-	}
-
-	info, err := cloneTask.WaitForResult(ctx, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "error cloning VM")
-	}
-
-	return object.NewVirtualMachine(srcClient.Client, info.Result.(types.ManagedObjectReference)), nil
-}
-
-func findVM(ctx context.Context, client *govmomi.Client, path string) (*object.VirtualMachine, error) {
-	searchIndex := object.NewSearchIndex(client.Client)
-	vmRef, err := searchIndex.FindByInventoryPath(ctx, path)
-	if err != nil {
-		return nil, errors.Wrap(err, "error searching for VM")
-	}
-	if vmRef == nil {
-		return nil, errors.Wrap(err, "couldn't find VM")
-	}
-
-	vm, ok := vmRef.(*object.VirtualMachine)
-	if !ok {
-		return nil, errors.Errorf("VM is not a VM but a %T", vmRef)
-	}
-
-	return vm, nil
-}
-
-func unregisterVM(ctx context.Context, client *govmomi.Client, path string) error {
-	vm, err := findVM(ctx, client, path)
-	if err != nil {
-		return errors.Wrap(err, "couldn't find VM to unregister")
-	}
-
-	return errors.Wrap(vm.Unregister(ctx), "couldn't unregister VM")
 }

--- a/cmd/vsphere-images/main.go
+++ b/cmd/vsphere-images/main.go
@@ -17,6 +17,7 @@ func main() {
 	app.Commands = []cli.Command{
 		copyImageCommand,
 		resnapshotCommand,
+		datastoreMoveCommand,
 	}
 
 	err := app.Run(os.Args)

--- a/cmd/vsphere-images/main.go
+++ b/cmd/vsphere-images/main.go
@@ -16,6 +16,7 @@ func main() {
 
 	app.Commands = []cli.Command{
 		copyImageCommand,
+		resnapshotCommand,
 	}
 
 	err := app.Run(os.Args)

--- a/cmd/vsphere-images/main.go
+++ b/cmd/vsphere-images/main.go
@@ -14,26 +14,6 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-var (
-	// VersionString is the git describe version set at build time
-	VersionString = "?"
-	// RevisionString is the git revision set at build time
-	RevisionString = "?"
-	// GeneratedString is the build date set at build time
-	GeneratedString = "?"
-)
-
-func init() {
-	cli.VersionPrinter = customVersionPrinter
-	os.Setenv("VERSION", VersionString)
-	os.Setenv("REVISION", RevisionString)
-	os.Setenv("GENERATED", GeneratedString)
-}
-
-func customVersionPrinter(c *cli.Context) {
-	fmt.Printf("%v v=%v rev=%v d=%v\n", c.App.Name, VersionString, RevisionString, GeneratedString)
-}
-
 func main() {
 	app := cli.NewApp()
 	app.Usage = "vSphere Image Manager"

--- a/cmd/vsphere-images/progress_logger.go
+++ b/cmd/vsphere-images/progress_logger.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/vmware/govmomi/vim25/progress"
+)
+
+type progressLogger struct {
+	prefix string
+	wg     sync.WaitGroup
+
+	sink chan chan progress.Report
+	done chan struct{}
+}
+
+func newProgressLogger(prefix string) *progressLogger {
+	p := &progressLogger{
+		prefix: prefix,
+
+		sink: make(chan chan progress.Report),
+		done: make(chan struct{}),
+	}
+
+	p.wg.Add(1)
+
+	go p.loopA()
+
+	return p
+}
+
+func (p *progressLogger) loopA() {
+	var err error
+
+	defer p.wg.Done()
+
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+
+	for stop := false; !stop; {
+		select {
+		case ch := <-p.sink:
+			err = p.loopB(tick, ch)
+			if err != nil {
+				stop = true
+			}
+		case <-p.done:
+			stop = true
+		case <-tick.C:
+			fmt.Fprintf(os.Stderr, "\r%s      ", p.prefix)
+		}
+	}
+
+	if err != nil && err != io.EOF {
+		fmt.Fprintf(os.Stderr, "\r%s      ", p.prefix)
+		fmt.Fprintf(os.Stderr, "\r%sError: %s\n", p.prefix, err)
+	} else {
+		fmt.Fprintf(os.Stderr, "\r%s      ", p.prefix)
+		fmt.Fprintf(os.Stderr, "\r%sOK\n", p.prefix)
+	}
+}
+
+func (p *progressLogger) loopB(tick *time.Ticker, ch <-chan progress.Report) error {
+	var r progress.Report
+	var ok bool
+	var err error
+
+	for ok = true; ok; {
+		select {
+		case r, ok = <-ch:
+			if !ok {
+				break
+			}
+			err = r.Error()
+		case <-tick.C:
+			line := "\r" + p.prefix
+			if r != nil {
+				line += fmt.Sprintf("(%.0f%%", r.Percentage())
+				detail := r.Detail()
+				if detail != "" {
+					line += fmt.Sprintf(", %s", detail)
+				}
+				line += ")"
+			}
+			fmt.Fprintf(os.Stderr, "%s", line)
+		}
+	}
+
+	return err
+}
+
+func (p *progressLogger) Sink() chan<- progress.Report {
+	ch := make(chan progress.Report)
+	p.sink <- ch
+	return ch
+}
+
+func (p *progressLogger) Wait() {
+	close(p.done)
+	p.wg.Wait()
+}

--- a/cmd/vsphere-images/resnapshot.go
+++ b/cmd/vsphere-images/resnapshot.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/pkg/errors"
+	vsphereimages "github.com/travis-ci/vsphere-images"
+	"github.com/urfave/cli"
+)
+
+var resnapshotCommand = cli.Command{
+	Name:      "resnapshot",
+	Usage:     "Remove (if it exists) and add a new 'base' snapshot to an image",
+	ArgsUsage: "image-inventory-path",
+	Action:    resnapshotAction,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:   "vsphere-url",
+			Usage:  "URL to the vSphere SDK API",
+			EnvVar: "VSPHERE_IMAGES_VSPHERE_URL",
+		},
+		cli.BoolFlag{
+			Name:   "vsphere-insecure-skip-verify",
+			Usage:  "Whether the vCenter's certificate chain and hostname should be verified",
+			EnvVar: "VSPHERE_IMAGES_VSPHERE_INSECURE_SKIP_VERIFY",
+		},
+	},
+}
+
+func resnapshotAction(c *cli.Context) error {
+	vSphereStringURL := c.String("vsphere-url")
+	if vSphereStringURL == "" {
+		return errors.New("the 'vsphere-url' flag is required")
+	}
+
+	vSphereURL, err := url.Parse(vSphereStringURL)
+	if err != nil {
+		return errors.Wrap(err, "parsing vSphere URL failed")
+	}
+
+	imagePath := c.Args().Get(0)
+	if imagePath == "" {
+		return errors.New("image inventory path is required")
+	}
+
+	ctx := context.Background()
+	logger := newProgressLogger("Snapshotting image… ")
+	err = vsphereimages.SnapshotImage(ctx, vSphereURL, c.Bool("vsphere-insecure-skip-verify"), imagePath, logger)
+	if err != nil {
+		return errors.Wrap(err, "snapshotting image failed")
+	}
+	logger.Wait()
+
+	return nil
+}

--- a/cmd/vsphere-images/version.go
+++ b/cmd/vsphere-images/version.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli"
+)
+
+var (
+	// VersionString is the git describe version set at build time
+	VersionString = "?"
+	// RevisionString is the git revision set at build time
+	RevisionString = "?"
+	// GeneratedString is the build date set at build time
+	GeneratedString = "?"
+)
+
+func init() {
+	cli.VersionPrinter = customVersionPrinter
+	os.Setenv("VERSION", VersionString)
+	os.Setenv("REVISION", RevisionString)
+	os.Setenv("GENERATED", GeneratedString)
+}
+
+func customVersionPrinter(c *cli.Context) {
+	fmt.Printf("%v v=%v rev=%v d=%v\n", c.App.Name, VersionString, RevisionString, GeneratedString)
+}

--- a/datastore_move_image.go
+++ b/datastore_move_image.go
@@ -1,0 +1,144 @@
+package vsphereimages
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/progress"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func DatastoreMoveImage(ctx context.Context, vSphereEndpoint *url.URL, vSphereInsecureSkipVerify bool, imageInventoryPath, srcDatastorePath, dstDatastorePath string, s progress.Sinker) error {
+	client, err := govmomi.NewClient(ctx, vSphereEndpoint, vSphereInsecureSkipVerify)
+	if err != nil {
+		return errors.Wrap(err, "creating vSphere client failed")
+	}
+
+	finder := find.NewFinder(client.Client, false)
+
+	vm, err := finder.VirtualMachine(ctx, imageInventoryPath)
+	if err != nil {
+		return errors.Wrap(err, "finding the VM failed")
+	}
+
+	var mvm mo.VirtualMachine
+	err = vm.Properties(ctx, vm.Reference(), []string{"datastore", "parent"}, &mvm)
+	if err != nil {
+		return errors.Wrap(err, "finding the VM's datastore failed")
+	}
+
+	if len(mvm.Datastore) != 1 {
+		return errors.Errorf("VM was expected to have 1 datastore, but had %d", len(mvm.Datastore))
+	}
+
+	var mds mo.Datastore
+	err = client.PropertyCollector().RetrieveOne(ctx, mvm.Datastore[0].Reference(), nil, &mds)
+	if err != nil {
+		return errors.Wrap(err, "getting information about datastore failed")
+	}
+
+	ds := object.NewDatastore(client.Client, mvm.Datastore[0])
+	e, err := finder.Element(ctx, mvm.Datastore[0])
+	if err != nil {
+		return errors.Wrap(err, "looking up datastore path failed")
+	}
+	ds.InventoryPath = e.Path
+
+	browser, err := ds.Browser(ctx)
+	if err != nil {
+		return errors.Wrap(err, "creating browser failed")
+	}
+
+	task, err := browser.SearchDatastore(ctx, ds.Path(srcDatastorePath), &types.HostDatastoreBrowserSearchSpec{
+		MatchPattern: []string{"*.vmx"},
+	})
+	if err != nil {
+		return errors.Wrap(err, "creating task to search for VM config file failed")
+	}
+
+	taskInfo, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "searching for VM config file failed")
+	}
+
+	var results []types.HostDatastoreBrowserSearchResults
+
+	switch r := taskInfo.Result.(type) {
+	case types.HostDatastoreBrowserSearchResults:
+		results = []types.HostDatastoreBrowserSearchResults{r}
+	case types.ArrayOfHostDatastoreBrowserSearchResults:
+		results = r.HostDatastoreBrowserSearchResults
+	default:
+		panic(fmt.Sprintf("unknown result type: %T", r))
+	}
+
+	var vmxFilename string
+	for _, result := range results {
+		for _, f := range result.File {
+			vmxFilename = f.GetFileInfo().Path
+			break
+		}
+	}
+	if vmxFilename == "" {
+		return errors.New("couldn't find *.vmx file in the source path")
+	}
+
+	if mvm.Parent == nil {
+		return errors.New("expected VM to have a parent, but was nil")
+	}
+	folder := object.NewFolder(client.Client, *mvm.Parent)
+
+	mes, err := mo.Ancestors(ctx, client.Client, client.Client.ServiceContent.PropertyCollector, ds.Reference())
+	if err != nil {
+		return errors.Wrap(err, "getting datastore's ancestors to find datacenter failed")
+	}
+
+	var dc *object.Datacenter
+	for _, me := range mes {
+		if me.Self.Type == "Datacenter" {
+			dc = object.NewDatacenter(client.Client, me.Self)
+			break
+		}
+	}
+	if dc == nil {
+		return errors.New("couldn't find a datacenter as an ancestor of the datastore")
+	}
+
+	pool, err := vm.ResourcePool(ctx)
+	if err != nil {
+		return errors.Wrap(err, "getting the VM's resource pool failed")
+	}
+
+	src := ds.Path(srcDatastorePath)
+	dst := ds.Path(dstDatastorePath)
+
+	err = vm.Unregister(ctx)
+	if err != nil {
+		return errors.Wrap(err, "unregistering the VM failed")
+	}
+
+	m := object.NewFileManager(client.Client)
+	task, err = m.MoveDatastoreFile(ctx, src, dc, dst, dc, false)
+	if err != nil {
+		return errors.Wrap(err, "creating task to move image files failed")
+	}
+
+	_, err = task.WaitForResult(ctx, s)
+	if err != nil {
+		return errors.Wrap(err, "moving image files in datastore failed")
+	}
+
+	task, err = folder.RegisterVM(ctx, dst+"/"+vmxFilename, "", false, pool, nil)
+	if err != nil {
+		return errors.Wrap(err, "creating task to register VM failed")
+	}
+
+	_, err = task.WaitForResult(ctx, s)
+	return errors.Wrap(err, "registering VM failed")
+}

--- a/image_copier.go
+++ b/image_copier.go
@@ -1,0 +1,201 @@
+package vsphereimages
+
+import (
+	"context"
+	"crypto/sha1"
+	"crypto/tls"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ImageSource struct {
+	// VSphereEndpoint is the URL to the vSphere API, including the
+	// credentials. Usually this is something like
+	// `https://user@password:your-vsphere-host/sdk`.
+	VSphereEndpoint *url.URL
+
+	// VSphereInsecureSkipVerify controls whether the server's certificate
+	// chain and hostname should be verified. If VSphereInsecureSkipVerify is
+	// true, any certificate presented by the server and any host name in that
+	// certificate will be accepted. See also
+	// crypto/tls.Config.InsecureSkipVerify.
+	VSphereInsecureSkipVerify bool
+
+	// VMPath is the inventory path to the source VM. This is usually something
+	// like `/your-datacenter/vm/folder-name/vm-name`.
+	VMPath string
+}
+
+type ImageDestination struct {
+	// VSphereEndpoint is the URL to the vSphere API, including the
+	// credentials. Usually this is something like
+	// `https://user@password:your-vsphere-host/sdk`.
+	VSphereEndpoint *url.URL
+
+	// VSphereInsecureSkipVerify controls whether the server's certificate
+	// chain and hostname should be verified. If VSphereInsecureSkipVerify is
+	// true, any certificate presented by the server and any host name in that
+	// certificate will be accepted. See also
+	// crypto/tls.Config.InsecureSkipVerify.
+	VSphereInsecureSkipVerify bool
+
+	// VSphereSHA1Fingerprint is the SHA-1 fingerprint of the vSphere API
+	// endpoint. It should be formatted as a series of :-separated uppercase
+	// hexadecimal numbers. If the string is empty, the ImageCopier will
+	// attempt to connect to the endpoint and use that fingerprint.
+	VSphereSHA1Fingerprint string
+
+	// FolderPath is the inventory path to the folder in the destination
+	// vCenter to copy the VM to. Folder inventory paths usually look something
+	// like `/your-datacenter/vm/folder-name`.
+	FolderPath string
+
+	// DatastorePath is the inventory path to the datastore in the destination
+	// vCenter to copy the VM to. Datastore inventory paths usually look
+	// something like `/your-datacenter/datastore/datastore-name`.
+	DatastorePath string
+
+	// ResourcePoolPath is the inventory path to the resource pool in the
+	// destination vCenter to copy the VM to. Resource pool paths usually look
+	// something like `/your-datacenter/host/pool-name`.
+	ResourcePoolPath string
+
+	// HostPath is the inventory path to the host in the destination vCenter to
+	// copy the VM to. Note that this host should be a part of the resource
+	// pool in ResourcePoolPath. Host inventory paths for hosts in a resource
+	// pool usually look something like
+	// `/your-datacenter/host/pool-name/host-name`.
+	HostPath string
+
+	// VMName is the name to give to the destination VM.
+	VMName string
+}
+
+func CopyImage(ctx context.Context, source ImageSource, destination ImageDestination) error {
+	srcClient, err := govmomi.NewClient(ctx, source.VSphereEndpoint, source.VSphereInsecureSkipVerify)
+	if err != nil {
+		return errors.Wrap(err, "creating source vSphere client failed")
+	}
+
+	destClient, err := govmomi.NewClient(ctx, destination.VSphereEndpoint, destination.VSphereInsecureSkipVerify)
+	if err != nil {
+		return errors.Wrap(err, "creating destination vSphere client failed")
+	}
+
+	srcFinder := find.NewFinder(srcClient.Client, false)
+	destFinder := find.NewFinder(destClient.Client, false)
+
+	srcVM, err := srcFinder.VirtualMachine(ctx, source.VMPath)
+	if err != nil {
+		return errors.Wrap(err, "finding the source VM failed")
+	}
+
+	destFolder, err := destFinder.Folder(ctx, destination.FolderPath)
+	if err != nil {
+		return errors.Wrap(err, "finding the destination folder failed")
+	}
+	destFolderRef := destFolder.Reference()
+
+	destDatastore, err := destFinder.Datastore(ctx, destination.DatastorePath)
+	if err != nil {
+		return errors.Wrap(err, "finding the destination datastore failed")
+	}
+	destDatastoreRef := destDatastore.Reference()
+
+	destPool, err := destFinder.ResourcePool(ctx, destination.ResourcePoolPath)
+	if err != nil {
+		return errors.Wrap(err, "finding the destination resource pool failed")
+	}
+	destPoolRef := destPool.Reference()
+
+	destHost, err := destFinder.HostSystem(ctx, destination.HostPath)
+	if err != nil {
+		return errors.Wrap(err, "finding the destination host failed")
+	}
+	destHostRef := destHost.Reference()
+
+	if destination.VSphereSHA1Fingerprint == "" {
+		hostPort := destination.VSphereEndpoint.Host
+		if !hasPort(hostPort) {
+			hostPort = hostPort + ":" + portMap[destination.VSphereEndpoint.Scheme]
+		}
+
+		destination.VSphereSHA1Fingerprint, err = findSHA1Fingerprint(hostPort)
+		if err != nil {
+			return errors.Wrap(err, "finding the SHA-1 fingerprint of the destination vCenter failed")
+		}
+	}
+
+	if destination.VSphereEndpoint.User == nil {
+		return errors.New("destination vSphere endpoint doesn't have username and password set")
+	}
+	username := destination.VSphereEndpoint.User.Username()
+	password, passwordSet := destination.VSphereEndpoint.User.Password()
+	if !passwordSet {
+		return errors.New("destination vSphere endpoint doesn't have password set")
+	}
+
+	cloneSpec := types.VirtualMachineCloneSpec{
+		Location: types.VirtualMachineRelocateSpec{
+			Service: &types.ServiceLocator{
+				Credential: &types.ServiceLocatorNamePassword{
+					Username: username,
+					Password: password,
+				},
+				InstanceUuid:  destClient.Client.ServiceContent.About.InstanceUuid,
+				SslThumbprint: destination.VSphereSHA1Fingerprint,
+				Url:           fmt.Sprintf("%s://%s", destination.VSphereEndpoint.Scheme, destination.VSphereEndpoint.Host),
+			},
+			Folder:    &destFolderRef,
+			Datastore: &destDatastoreRef,
+			Pool:      &destPoolRef,
+			Host:      &destHostRef,
+		},
+	}
+
+	cloneTask, err := srcVM.Clone(ctx, destFolder, destination.VMName, cloneSpec)
+	if err != nil {
+		return errors.Wrap(err, "creating VM clone task failed")
+	}
+
+	return errors.Wrap(cloneTask.Wait(ctx), "cloning VM failed")
+}
+
+func findSHA1Fingerprint(hostport string) (string, error) {
+	conn, err := tls.Dial("tcp", hostport, &tls.Config{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "dial failed")
+	}
+
+	err = conn.Handshake()
+	if err != nil {
+		return "", errors.Wrap(err, "handshake failed")
+	}
+
+	certificate := conn.ConnectionState().PeerCertificates[0]
+	sha1Fingerprint := sha1.Sum(certificate.Raw)
+	formattedFingerprint := make([]string, 0, len(sha1Fingerprint))
+	for _, b := range sha1Fingerprint {
+		formattedFingerprint = append(formattedFingerprint, fmt.Sprintf("%02X", b))
+	}
+	return strings.Join(formattedFingerprint, ":"), nil
+}
+
+var portMap = map[string]string{
+	"http":  "80",
+	"https": "443",
+}
+
+// Given a string of the form "host", "host:port", or "[ipv6::address]:port",
+// return true if the string includes a port.
+//
+// Copied from Go 1.7 net/http: https://github.com/golang/go/blob/230a376b5a67f0e9341e1fa47e670ff762213c83/src/net/http/http.go
+func hasPort(s string) bool { return strings.LastIndex(s, ":") > strings.LastIndex(s, "]") }

--- a/image_copier_test.go
+++ b/image_copier_test.go
@@ -1,0 +1,28 @@
+package vsphereimages_test
+
+import (
+	"context"
+	"net/url"
+
+	vsphereimages "github.com/travis-ci/vsphere-images"
+)
+
+func ExampleCopyImage() {
+	vSphereSourceURL, _ := url.Parse("https://admin@password:vsphere1.example.com/sdk")
+	vSphereDestinationURL, _ := url.Parse("https://admin@password:vsphere2.example.com/sdk")
+
+	source := vsphereimages.ImageSource{
+		VSphereEndpoint: vSphereSourceURL,
+		VMPath:          "/dc01/vm/base vms/foo",
+	}
+	destination := vsphereimages.ImageDestination{
+		VSphereEndpoint:  vSphereDestinationURL,
+		FolderPath:       "/dc02/vm/base vms/",
+		DatastorePath:    "/dc02/datastore/main-datastore",
+		ResourcePoolPath: "/dc02/host/main-pool",
+		HostPath:         "/dc02/host/main-pool/host01",
+		VMName:           "foo",
+	}
+
+	vsphereimages.CopyImage(context.TODO(), source, destination)
+}

--- a/image_copier_test.go
+++ b/image_copier_test.go
@@ -24,5 +24,5 @@ func ExampleCopyImage() {
 		VMName:           "foo",
 	}
 
-	vsphereimages.CopyImage(context.TODO(), source, destination)
+	vsphereimages.CopyImage(context.TODO(), source, destination, nil)
 }

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,43 @@
+package vsphereimages
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/pkg/errors"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/vim25/progress"
+)
+
+func SnapshotImage(ctx context.Context, vSphereEndpoint *url.URL, vSphereInsecureSkipVerify bool, imageInventoryPath string, s progress.Sinker) error {
+	client, err := govmomi.NewClient(ctx, vSphereEndpoint, vSphereInsecureSkipVerify)
+	if err != nil {
+		return errors.Wrap(err, "creating vSphere client failed")
+	}
+
+	finder := find.NewFinder(client.Client, false)
+
+	vm, err := finder.VirtualMachine(ctx, imageInventoryPath)
+	if err != nil {
+		return errors.Wrap(err, "finding the VM failed")
+	}
+
+	removeTask, err := vm.RemoveAllSnapshot(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "creating task to remove all snapshots failed")
+	}
+
+	_, err = removeTask.WaitForResult(ctx, s)
+	if err != nil {
+		return errors.Wrap(err, "removing all snapshots failed")
+	}
+
+	createTask, err := vm.CreateSnapshot(ctx, "base", "", false, false)
+	if err != nil {
+		return errors.Wrap(err, "creating task to create snapshot failed")
+	}
+
+	_, err = createTask.WaitForResult(ctx, s)
+	return errors.Wrap(err, "creating snapshot failed")
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -10,6 +10,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/pkg/errors",
+			"repository": "https://github.com/pkg/errors",
+			"vcs": "git",
+			"revision": "248dadf4e9068a0b3e79f02ed0a610d935de5302",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/urfave/cli",
 			"repository": "https://github.com/urfave/cli",
 			"vcs": "git",


### PR DESCRIPTION
This is a WIP, please don't merge it yet.

To do:

- [x] Update the network card on the destination VM after cloning. The vSphere API docs seem to indicate that this can be done with some setting on the clone itself, but I have been unable to find it, so I think it's probably easier to just reconfigure the VM after cloning.
- [x] Create a new "base" snapshot after cloning the VM. I'm thinking I'll make a separate file and function for this in the root package, as I'd like to add a CLI command to "resnapshot" in the future, so having that as a separate function would be helpful (also the copy function is getting _really_ long already).