### PR TITLE
Add automatic moving of hosts when checking in/out

### DIFF
--- a/cmd/vsphere-images/checkin-host.go
+++ b/cmd/vsphere-images/checkin-host.go
@@ -28,7 +28,7 @@ var checkinHostCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:  "dest-pool",
-			Usage: "Path to cluster where the host will be moved (currently unused)",
+			Usage: "Path to cluster where the host will be moved",
 		},
 	},
 }
@@ -63,7 +63,6 @@ func checkinHostAction(c *cli.Context) error {
 	logger.Wait()
 
 	fmt.Println("Checked in host", host.Name())
-	fmt.Println("Please move it to the desired cluster manually using the vCenter client.")
 
 	return nil
 }

--- a/cmd/vsphere-images/checkout-host.go
+++ b/cmd/vsphere-images/checkout-host.go
@@ -66,7 +66,6 @@ func checkoutHostAction(c *cli.Context) error {
 		fmt.Println("No suitable host to check out was found")
 	} else {
 		fmt.Println("Checked out host", host.Name())
-		fmt.Println("Please move it to the desired cluster manually using the vCenter client.")
 	}
 
 	return nil

--- a/dedicate.go
+++ b/dedicate.go
@@ -10,7 +10,9 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/progress"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 func CheckOutHost(ctx context.Context, vSphereEndpoint *url.URL, vSphereInsecureSkipVerify bool, clusterInventoryPath string, destinationClusterPath string, s progress.Sinker) (*object.HostSystem, error) {
@@ -39,6 +41,11 @@ func CheckOutHost(ctx context.Context, vSphereEndpoint *url.URL, vSphereInsecure
 		return nil, errors.New("no hosts found in cluster")
 	}
 
+	cluster, err := finder.ClusterComputeResource(ctx, destinationClusterPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "finding the destination cluster failed")
+	}
+
 	chosenHost, err := chooseAvailableHost(ctx, hosts, finder)
 	if err != nil {
 		return nil, err
@@ -46,12 +53,32 @@ func CheckOutHost(ctx context.Context, vSphereEndpoint *url.URL, vSphereInsecure
 
 	task, err := chosenHost.EnterMaintenanceMode(ctx, 0, true, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating the maintenance mode task failed")
+		return nil, errors.Wrap(err, "creating the enter maintenance mode task failed")
 	}
 
 	_, err = task.WaitForResult(ctx, s)
 	if err != nil {
 		return nil, errors.Wrap(err, "moving the host into maintenance mode failed")
+	}
+
+	task, err = moveHostToCluster(ctx, chosenHost, cluster)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating the move host task failed")
+	}
+
+	_, err = task.WaitForResult(ctx, s)
+	if err != nil {
+		return nil, errors.Wrap(err, "moving host to destination cluster failed")
+	}
+
+	task, err = chosenHost.ExitMaintenanceMode(ctx, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating the exit maintenance mode task failed")
+	}
+
+	_, err = task.WaitForResult(ctx, s)
+	if err != nil {
+		return nil, errors.Wrap(err, "bringing the host out of maintenance mode failed")
 	}
 
 	return chosenHost, nil
@@ -78,14 +105,39 @@ func CheckInHost(ctx context.Context, vSphereEndpoint *url.URL, vSphereInsecureS
 		return nil, errors.New("more than 1 host found in cluster (maybe this is the wrong cluster?)")
 	}
 
+	cluster, err := finder.ClusterComputeResource(ctx, destinationClusterPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "finding the destination cluster failed")
+	}
+
 	task, err := hosts[0].EnterMaintenanceMode(ctx, 0, true, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating the maintenance mode task failed")
+		return nil, errors.Wrap(err, "creating the enter maintenance mode task failed")
 	}
 
 	_, err = task.WaitForResult(ctx, s)
 	if err != nil {
 		return nil, errors.Wrap(err, "moving the host into maintenance mode failed")
+	}
+
+	task, err = moveHostToCluster(ctx, hosts[0], cluster)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating the move host task failed")
+	}
+
+	_, err = task.WaitForResult(ctx, s)
+	if err != nil {
+		return nil, errors.Wrap(err, "moving host to destination cluster failed")
+	}
+
+	task, err = hosts[0].ExitMaintenanceMode(ctx, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating the exit maintenance mode task failed")
+	}
+
+	_, err = task.WaitForResult(ctx, s)
+	if err != nil {
+		return nil, errors.Wrap(err, "bringing the host out of maintenance mode failed")
 	}
 
 	return hosts[0], nil
@@ -159,4 +211,24 @@ var buildVMNameRegexp = regexp.MustCompile("^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:
 
 func isBuildVMName(name string) bool {
 	return buildVMNameRegexp.MatchString(name)
+}
+
+func moveHostToCluster(ctx context.Context, host *object.HostSystem, destinationCluster *object.ClusterComputeResource) (*object.Task, error) {
+	// The structure of this method is largely copied from existing methods from the 'object' package in govmomi.
+	// The pattern of creating a task, then calling the 'methods' version of it, and returning a new task wrapping
+	// the result is how other real APIs on govmomi objects are done.
+	//
+	// There isn't a function on ClusterComputeResource to run this task, though, so we have to do this part ourselves.
+
+	req := types.MoveInto_Task{
+		This: destinationCluster.Reference(),
+		Host: []types.ManagedObjectReference{host.Reference()},
+	}
+
+	res, err := methods.MoveInto_Task(ctx, destinationCluster.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(destinationCluster.Client(), res.Returnval), nil
 }


### PR DESCRIPTION
I finally figured out how to move hosts between clusters automatically, so this eliminates the pesky manual step in checking hosts in/out of packer_image_dev.

I'm going to look at opening a PR on govmomi to add the convenience wrapper directly on the proper object type in there. If they accept that change, we can remove our wrapper later.